### PR TITLE
Modify some of the test expectations

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ The cart sample uses Vagrant to provision and configure a Virtual Machine that s
 
 Note: We expect installation to take 15-30 minutes to setup. If for any reason it is taking longer, please feel free to reach out to us. We are happy to [help](#support).
 
+### Windows Users
+
+If you are using a Windows machine, you may encounter some problems getting Vagrant working. Please read [Getting Started with Vagrant on Windows](http://www.sitepoint.com/getting-started-vagrant-windows/) for some Windows specific instructions.
+
 ## Running Tests
 
 After installation, ssh into the vagrant box and confirm the tests are working:
@@ -42,14 +46,12 @@ Here is a high level overview of the important files in this project:
    * `features/bootstrap/FeatureContext.php` - the Behat file that parses the above `cart.feature` and executes tests.
    * `src/HauteLook/Cart.php` - the sample cart class
 
-Vagrant will automatically sync any changes you make to these files from your host operating system, so feel free to use whatever editor your are most comfortable with to browse and edit them.
+You may need to add additional files or classes to complete the assignment. Vagrant will automatically sync any changes you make to these files from your host operating system, so feel free to use whatever editor your are most comfortable with to browse and edit them.
 
 ## Challenge
 
-The first scenario has been written for you. Please implement as many of the remaining scenarios in `features/cart.feature' as you can within the next 60 minutes. We are judging you on the simplcity of your design and the correctness of the code. Make whatever changes you want to the scenario implementations and source code to accomplish that goal. Do not worry if you cannot finish all of them. Find a good stopping point and send us what you have. We are excited to see it! Zip up the entire directory and email it back to us.
+The first scenario has been written for you. Please implement the remaining scenarios in `features/cart.feature'. We are judging you on the design and the correctness of the code. Make whatever changes you want to the scenario implementations and source code to accomplish that goal. We are excited to see it! Zip up the directory and email it back to us. You can omit the `.git` and `vendor` directories when creating the zip.
 
 ### Support
 
 Need help? Please reach out to us! We know computers can be tricky things and we are happy to assist you. Our contact details are in the email we sent you. We will get back to you as soon as we can.
-
-


### PR DESCRIPTION
- Provide some guidance to Windows users
- Remove expectation that will take 60 minutes. Some people work at
  different speeds.
- Remove expectation that it is acceptable to not complete the test.
  Some of the behat tests at the end are the most difficult and we want
  to see those.
- Remove the expectation that we want _simple_ design. People should
  present to us what they believe the proper design is.
- Mentioned that more files or classes may need to be added. Some people
  were under the impression that they could not add more classes.